### PR TITLE
Update cr_reject.py

### DIFF
--- a/wfc3_phot_tools/spatial_scan/cr_reject.py
+++ b/wfc3_phot_tools/spatial_scan/cr_reject.py
@@ -541,7 +541,7 @@ def make_crcorr_file_scan_wfc3(input_file, mult=4, output_dir=None, ext=1,
         output_dir = os.path.dirname(input_file)
 
     # Check that input file is either an FLT or FLC file.
-    file_type = os.path.basename(input_file).split('-')[-1].split('.')[0]
+    file_type = os.path.basename(input_file).split('_')[-1].split('.')[0]
     if file_type not in ['flt', 'flc']:
         raise ValueError(f'Input file is {file_type}, but only FLT or FLC '\
                          'files are valid.')


### PR DESCRIPTION
I was hitting this error in the script:

"ValueError: Input file is ifj410xhq_flt, but only FLT or FLC files are valid."

this is because the string was being split on a hyphen "-" instead of an underscore "_". 

This PR fixes that, and it correctly gets the file type as flt. :)